### PR TITLE
HN feedback: auto-copy URLs, pawn promotion, README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,22 @@
 # DM-Chess
 
-Play chess with a colleague right from your DMs. No apps, no logins — just copy, paste, and play.
+Play chess with a coworker over Slack, Teams, or whatever you use. You make a move in the browser, the share link auto-copies to your clipboard, you paste it. They click, make their move, paste the new link back. That's it.
+
+No accounts, no installs, no servers.
+
+**[dvelton.github.io/dm-chess](https://dvelton.github.io/dm-chess)**
 
 ![DM-Chess Screenshot](screenshot1.png)
 
-## What is this?
+## How to play
 
-DM-Chess is a lightweight chess game you play by sharing text over Slack, Teams, or any messaging app. Make your move in the browser, copy the game state, paste it to your opponent. They paste it back into their browser, make their move, and send it back.
+1. Open the app and click a piece, then click where it should go.
+2. The share link copies to your clipboard automatically after each move.
+3. Paste the link to your opponent in Slack/Teams/email/whatever.
+4. They open it, make their move, send the new link back.
+5. Keep going until someone wins or you both get bored.
 
-There's nothing to install and no accounts to create.
-
-**Play it here: [dvelton.github.io/dm-chess](https://dvelton.github.io/dm-chess)**
-
-## How it works
-
-1. Open the app and make your move by clicking a piece and then its destination.
-2. Go to the **Share** tab and either:
-   - **Copy the ASCII text** and paste it in Slack/Teams, or
-   - **Copy a share link** your opponent can open directly.
-3. Your opponent loads the game (paste text + "Load Game", or just open the link), makes their move, and sends it back.
-4. Repeat until checkmate.
-
-The game auto-saves in your browser between sessions.
-
-## Features
-
-- Full chess rules via [chess.js](https://github.com/jhlywa/chess.js) — check, checkmate, stalemate, castling, en passant, pawn promotion, draw detection
-- ASCII board output for sharing in any text channel
-- URL-based sharing (game state encoded in query params)
-- Move history with step-through replay
-- Captured piece tracking
-- Persistent local storage — close the tab and come back later
+You can also use the Share tab to copy an ASCII text version of the board if you prefer the old-school look in chat. The game auto-saves in your browser, so closing the tab won't lose your position.
 
 ## Screenshots
 
@@ -45,17 +31,15 @@ npm install
 npm run dev
 ```
 
-Build for production:
+Production build:
 
 ```bash
 npm run build
 ```
 
-Deploys automatically to GitHub Pages on push to `main`.
+Deploys to GitHub Pages on push to `main`.
 
-## Tech stack
-
-React, TypeScript, Vite, Tailwind CSS, chess.js, Radix UI primitives.
+Built with React, TypeScript, Vite, Tailwind CSS, [chess.js](https://github.com/jhlywa/chess.js), and Radix UI. Originally made with [GitHub Spark](https://github.com/features/spark).
 
 ## License
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import AsciiBoard from '@/components/AsciiBoard';
 import GameControls from '@/components/GameControls';
 import MoveHistory from '@/components/MoveHistory';
 import HelpDialog from '@/components/HelpDialog';
+import { useToast, ToastContainer } from '@/components/Toast';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -38,6 +39,27 @@ function App() {
 
   const [currentMoveIndex, setCurrentMoveIndex] = useState<number>(-1);
   const [replayState, setReplayState] = useState<GameState | null>(null);
+  const { toasts, showToast } = useToast();
+
+  // Build a share URL for the given game state
+  const buildShareUrl = useCallback((state: GameState): string => {
+    const encoded = serializeForUrl(state);
+    const url = new URL(window.location.href);
+    url.search = encoded ? `?moves=${encoded}` : '';
+    return url.toString();
+  }, []);
+
+  // Copy a share URL to clipboard, return it
+  const copyShareUrl = useCallback(async (state: GameState): Promise<string> => {
+    const url = buildShareUrl(state);
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast('Share link copied to clipboard');
+    } catch {
+      showToast('Move made (clipboard unavailable)');
+    }
+    return url;
+  }, [buildShareUrl, showToast]);
 
   const updateGameState = (newState: GameState) => {
     setGameState(newState);
@@ -50,12 +72,12 @@ function App() {
     updateGameState(newState);
     setCurrentMoveIndex(-1);
     setReplayState(null);
-    // Clear URL params
     window.history.replaceState({}, '', window.location.pathname);
   };
 
-  const handleMove = (newState: GameState) => {
+  const handleMove = async (newState: GameState) => {
     updateGameState(newState);
+    await copyShareUrl(newState);
   };
 
   const handleImport = (importedState: GameState) => {
@@ -75,13 +97,7 @@ function App() {
   };
 
   const handleShareLink = async () => {
-    const encoded = serializeForUrl(gameState);
-    const url = new URL(window.location.href);
-    url.search = encoded ? `?moves=${encoded}` : '';
-    try {
-      await navigator.clipboard.writeText(url.toString());
-    } catch { /* fallback: silent */ }
-    return url.toString();
+    return await copyShareUrl(gameState);
   };
 
   useEffect(() => {
@@ -188,8 +204,10 @@ function App() {
       </main>
       
       <footer className="mt-8 text-center text-sm text-muted-foreground">
-        <p>DM-Chess — play chess over DMs without accounts or third-party services.</p>
+        <p>DM-Chess -- play chess over DMs without accounts or third-party services.</p>
       </footer>
+
+      <ToastContainer toasts={toasts} />
     </div>
   );
 }

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { GameState, Piece, Position, isValidMove, makeMove, getValidMoves } from '@/lib/chess';
+import { GameState, Piece, Position, PieceType, isValidMove, makeMove, getValidMoves, isPromotionMove } from '@/lib/chess';
 import { cn } from '@/lib/utils';
+import PromotionDialog from '@/components/PromotionDialog';
 
 interface ChessBoardProps {
   gameState: GameState;
@@ -12,6 +13,7 @@ interface ChessBoardProps {
 export default function ChessBoard({ gameState, onMove, viewMode = false, displayState }: ChessBoardProps) {
   const [selectedSquare, setSelectedSquare] = useState<Position | null>(null);
   const [hoveredSquare, setHoveredSquare] = useState<Position | null>(null);
+  const [pendingPromotion, setPendingPromotion] = useState<{ from: Position; to: Position } | null>(null);
   
   // Use displayState if provided (for move history replay), otherwise use gameState
   const boardToDisplay = displayState || gameState;
@@ -27,6 +29,11 @@ export default function ChessBoard({ gameState, onMove, viewMode = false, displa
     if (selectedSquare) {
       // Attempt to make a move
       if (isValidMove(gameState, selectedSquare, clickedPosition)) {
+        if (isPromotionMove(gameState, selectedSquare, clickedPosition)) {
+          setPendingPromotion({ from: selectedSquare, to: clickedPosition });
+          setSelectedSquare(null);
+          return;
+        }
         const newState = makeMove(gameState, selectedSquare, clickedPosition);
         onMove(newState);
       }
@@ -40,6 +47,13 @@ export default function ChessBoard({ gameState, onMove, viewMode = false, displa
         setSelectedSquare(clickedPosition);
       }
     }
+  };
+
+  const handlePromotionSelect = (pieceType: PieceType) => {
+    if (!pendingPromotion) return;
+    const newState = makeMove(gameState, pendingPromotion.from, pendingPromotion.to, pieceType);
+    onMove(newState);
+    setPendingPromotion(null);
   };
 
   // Render a chess piece based on its type and color using Unicode characters
@@ -97,52 +111,59 @@ export default function ChessBoard({ gameState, onMove, viewMode = false, displa
   };
 
   return (
-    <div className="board-container">
-      <div className="grid grid-cols-8 grid-rows-8 h-full w-full border border-border rounded overflow-hidden">
-        {boardToDisplay.board.map((row, rowIndex) => (
-          row.map((piece, colIndex) => {
-            const isLightSquare = (rowIndex + colIndex) % 2 === 0;
-            const isSelected = !viewMode && selectedSquare?.row === rowIndex && selectedSquare?.col === colIndex;
-            const isValidTarget = isValidMoveTarget(rowIndex, colIndex);
-            const isHighlighted = isLastMove(rowIndex, colIndex);
-            const isHovered = !viewMode && hoveredSquare?.row === rowIndex && hoveredSquare?.col === colIndex;
-            
-            return (
-              <div
-                key={`${rowIndex}-${colIndex}`}
-                className={cn(
-                  "flex items-center justify-center relative",
-                  isLightSquare ? "chess-square-light" : "chess-square-dark",
-                  isSelected && "ring-2 ring-accent ring-inset",
-                  isValidTarget && "bg-accent/25",
-                  isHighlighted && "ring-1 ring-accent/70 ring-inset",
-                  isHovered && "brightness-110",
-                  viewMode ? "cursor-default" : ""
-                )}
-                onClick={() => handleSquareClick(rowIndex, colIndex)}
-                onMouseEnter={() => !viewMode && setHoveredSquare({ row: rowIndex, col: colIndex })}
-                onMouseLeave={() => !viewMode && setHoveredSquare(null)}
-              >
-                <div className={cn("chess-piece", piece && "z-10")}>
-                  {renderPiece(piece)}
+    <>
+      <div className="board-container">
+        <div className="grid grid-cols-8 grid-rows-8 h-full w-full border border-border rounded overflow-hidden">
+          {boardToDisplay.board.map((row, rowIndex) => (
+            row.map((piece, colIndex) => {
+              const isLightSquare = (rowIndex + colIndex) % 2 === 0;
+              const isSelected = !viewMode && selectedSquare?.row === rowIndex && selectedSquare?.col === colIndex;
+              const isValidTarget = isValidMoveTarget(rowIndex, colIndex);
+              const isHighlighted = isLastMove(rowIndex, colIndex);
+              const isHovered = !viewMode && hoveredSquare?.row === rowIndex && hoveredSquare?.col === colIndex;
+              
+              return (
+                <div
+                  key={`${rowIndex}-${colIndex}`}
+                  className={cn(
+                    "flex items-center justify-center relative",
+                    isLightSquare ? "chess-square-light" : "chess-square-dark",
+                    isSelected && "ring-2 ring-accent ring-inset",
+                    isValidTarget && "bg-accent/25",
+                    isHighlighted && "ring-1 ring-accent/70 ring-inset",
+                    isHovered && "brightness-110",
+                    viewMode ? "cursor-default" : ""
+                  )}
+                  onClick={() => handleSquareClick(rowIndex, colIndex)}
+                  onMouseEnter={() => !viewMode && setHoveredSquare({ row: rowIndex, col: colIndex })}
+                  onMouseLeave={() => !viewMode && setHoveredSquare(null)}
+                >
+                  <div className={cn("chess-piece", piece && "z-10")}>
+                    {renderPiece(piece)}
+                  </div>
+                  
+                  {colIndex === 0 && (
+                    <div className="absolute left-1 top-0 text-xs opacity-70">
+                      {8 - rowIndex}
+                    </div>
+                  )}
+                  {rowIndex === 7 && (
+                    <div className="absolute bottom-0 right-1 text-xs opacity-70">
+                      {String.fromCharCode(97 + colIndex)}
+                    </div>
+                  )}
                 </div>
-                
-                {/* Coordinates on the edges of the board */}
-                {colIndex === 0 && (
-                  <div className="absolute left-1 top-0 text-xs opacity-70">
-                    {8 - rowIndex}
-                  </div>
-                )}
-                {rowIndex === 7 && (
-                  <div className="absolute bottom-0 right-1 text-xs opacity-70">
-                    {String.fromCharCode(97 + colIndex)}
-                  </div>
-                )}
-              </div>
-            );
-          })
-        ))}
+              );
+            })
+          ))}
+        </div>
       </div>
-    </div>
+
+      <PromotionDialog
+        open={pendingPromotion !== null}
+        color={gameState.turn}
+        onSelect={handlePromotionSelect}
+      />
+    </>
   );
 }

--- a/src/components/PromotionDialog.tsx
+++ b/src/components/PromotionDialog.tsx
@@ -1,0 +1,47 @@
+import { PieceType } from '@/lib/chess';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface PromotionDialogProps {
+  open: boolean;
+  color: 'w' | 'b';
+  onSelect: (piece: PieceType) => void;
+}
+
+const promotionPieces: { type: PieceType; label: string; white: string; black: string }[] = [
+  { type: 'q', label: 'Queen', white: '♕', black: '♛' },
+  { type: 'r', label: 'Rook', white: '♖', black: '♜' },
+  { type: 'b', label: 'Bishop', white: '♗', black: '♝' },
+  { type: 'n', label: 'Knight', white: '♘', black: '♞' },
+];
+
+export default function PromotionDialog({ open, color, onSelect }: PromotionDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="max-w-xs" onPointerDownOutside={e => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Promote pawn</DialogTitle>
+        </DialogHeader>
+        <div className="grid grid-cols-4 gap-2 py-2">
+          {promotionPieces.map(p => (
+            <button
+              key={p.type}
+              onClick={() => onSelect(p.type)}
+              className="flex flex-col items-center gap-1 p-3 rounded-md hover:bg-muted transition-colors border"
+              title={p.label}
+            >
+              <span className="text-4xl select-none">
+                {color === 'w' ? p.white : p.black}
+              </span>
+              <span className="text-xs text-muted-foreground">{p.label}</span>
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+let toastId = 0;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, duration = 2500) => {
+    const id = ++toastId;
+    setToasts(prev => [...prev, { id, message }]);
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id));
+    }, duration);
+  }, []);
+
+  return { toasts, showToast };
+}
+
+export function ToastContainer({ toasts }: { toasts: Toast[] }) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex flex-col gap-2 items-center">
+      {toasts.map(toast => (
+        <ToastItem key={toast.id} message={toast.message} />
+      ))}
+    </div>
+  );
+}
+
+function ToastItem({ message }: { message: string }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  return (
+    <div
+      className={`
+        px-4 py-2 rounded-md shadow-lg border
+        bg-card text-card-foreground text-sm font-medium
+        transition-all duration-300 ease-out
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}
+      `}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/lib/chess.ts
+++ b/src/lib/chess.ts
@@ -181,6 +181,14 @@ export function isValidMove(gameState: GameState, from: Position, to: Position):
   return moves.some(m => m.to === toSq);
 }
 
+// Check if a move would be a pawn promotion
+export function isPromotionMove(gameState: GameState, from: Position, to: Position): boolean {
+  const piece = gameState.board[from.row][from.col];
+  if (!piece || piece.type !== 'p') return false;
+  const targetRow = piece.color === 'w' ? 0 : 7;
+  return to.row === targetRow && isValidMove(gameState, from, to);
+}
+
 // Get all valid moves for a piece at a position
 export function getValidMoves(gameState: GameState, from: Position): Position[] {
   const chess = gameStateToChess(gameState);


### PR DESCRIPTION
Three changes based on feedback from the [HN discussion](https://news.ycombinator.com/item?id=46580506):

**Auto-copy share URL after each move** — The most-requested feature. After making a move, the share link is automatically copied to clipboard and a brief toast confirms it. Players can immediately paste the link to their opponent without visiting the Share tab. The manual "Copy Share Link" button still works too.

**Pawn promotion dialog** — Pawn promotions previously defaulted to queen with no option to choose. Now a dialog appears with queen/rook/bishop/knight options. Won't come up often, but it matters when it does.

**README rewrite** — Several commenters called out the README formatting. Rewrote it to be shorter and more direct, dropped the feature list that repeated the same information three times.